### PR TITLE
Add fiber photometry metadata

### DIFF
--- a/src/howe_lab_to_nwb/vu2024/metadata/vu2024_fiber_photometry_metadata.yaml
+++ b/src/howe_lab_to_nwb/vu2024/metadata/vu2024_fiber_photometry_metadata.yaml
@@ -1,0 +1,185 @@
+Ophys:
+  FiberPhotometry:
+    FiberPhotometryTable:
+       name: FiberPhotometryTable
+       description: Contains the metadata for the fiber photometry experiment.
+    OpticalFibers:
+      - name: Fiber34
+        description: The optical fiber used in a multi-fiber arrays configuration, fabricated in-house to enable large scale measurements across deep brain volumes.
+          Bare fibers were cut into pieces (ca. 3cm) then mounted under a microscope into 55-60μm diameter holes in a custom 3D printed grid (3mm W x 5mm L, Boston Micro Fabrication), 
+          measured under a dissection microscope to target a particular depth beneath the grid, and secured in place with UV glue (Norland Optical Adhesive 61). 
+          Each array contained between 30 and 103 fibers separated by a minimum of 220μm radially and 250μm axially. 
+          Separation was calculated to achieve maximal coverage of the striatum volume with no overlap in the collection fields of individual fibers.
+          Fibers were cut with a fiber scribe, and the distal ends were inspected to ensure a uniform cut, and re-cut as necessary. 
+          Distal ends were then glued inside an 1cm ca. section of polyimide tube (0.8-1.3mm diameter, MicroLumen) then cut with a fresh razorblade. 
+          The bundled fibers inside the tube were then polished on fine grained polishing paper (ThorLabs,polished first with 6 μm, followed by 3 μm) to create a smooth, 
+          uniform fiber bundle surface for imaging. 
+          A larger diameter post was mounted on one side of the plastic grid to facilitate holding during implantation.
+        manufacturer: Fiber Optics Tech
+        model: not specified
+        numerical_aperture: 0.66
+        core_diameter_in_um: 34.0
+      - name: Fiber46
+        description: The optical fiber used in a multi-fiber arrays configuration, fabricated in-house to enable large scale measurements across deep brain volumes.
+          Bare fibers were cut into pieces (ca. 3cm) then mounted under a microscope into 55-60μm diameter holes in a custom 3D printed grid (3mm W x 5mm L, Boston Micro Fabrication), 
+          measured under a dissection microscope to target a particular depth beneath the grid, and secured in place with UV glue (Norland Optical Adhesive 61). 
+          Each array contained between 30 and 103 fibers separated by a minimum of 220μm radially and 250μm axially. 
+          Separation was calculated to achieve maximal coverage of the striatum volume with no overlap in the collection fields of individual fibers.
+          Fibers were cut with a fiber scribe, and the distal ends were inspected to ensure a uniform cut, and re-cut as necessary. 
+          Distal ends were then glued inside an 1cm ca. section of polyimide tube (0.8-1.3mm diameter, MicroLumen) then cut with a fresh razorblade. 
+          The bundled fibers inside the tube were then polished on fine grained polishing paper (ThorLabs,polished first with 6 μm, followed by 3 μm) to create a smooth, 
+          uniform fiber bundle surface for imaging. 
+          A larger diameter post was mounted on one side of the plastic grid to facilitate holding during implantation.
+        manufacturer: Fiber Optics Tech
+        model: not specified
+        numerical_aperture: 0.66
+        core_diameter_in_um: 46.0
+    ExcitationSources:
+      - name: ExcitationSource470
+        description: |
+         Blue excitation light (470 nm LED, Thorlabs, No. SOLIS-470C) and violet excitation light (for the isosbestic control)
+         were coupled into the optic fiber such that a power of 0.75 mW was delivered to the fiber tip.
+         Then, 470 nm and 405 nm excitation were alternated at 100 Hz using a waveform generator,
+         each filtered with a corresponding filter.
+        manufacturer: Thorlabs
+        model: SOLIS-470C
+        excitation_wavelength_in_nm: 470.0
+        illumination_type: LED
+      - name: ExcitationSource405
+        description: Violet LED (405 nm, Thorlabs, No. SOLIS-405C) for the isosbestic control.
+        manufacturer: Thorlabs
+        model: SOLIS-405C
+        excitation_wavelength_in_nm: 405.0
+        illumination_type: LED
+      - name: ExcitationSource415
+        description: 415 nm LED, Thorlabs, No. SOLIS-415C
+        manufacturer: Thorlabs
+        model: SOLIS-415C
+        excitation_wavelength_in_nm: 415.0
+        illumination_type: LED
+      - name: ExcitationSource570
+        description: 405 nm, Thorlabs, No. SOLIS-570C
+        manufacturer: Thorlabs
+        model: SOLIS-570C
+        excitation_wavelength_in_nm: 570.0
+        illumination_type: LED
+    Devices:
+      - name: CMOSCamera
+        description:  A tube lens in each path (Thor labs, No TTL165-A) focused emission light onto the CMOS sensors of the cameras to form an image of the fiber bundle.
+        manufacturer: Hamamatsu Photonics, Orca Fusion BT Gen III
+      - name: LiquidLightGuide
+        description:  The liquid light guide is coupled into a filter cube on the microscope and excitation light is reflected into the back aperture of the microscope objective by a dichroic beam-splitter.
+        manufacturer: Newport, model No. 77632
+      - name: Lens1
+        description:  Lens focus at 60 mm.
+        manufacturer: Thorlabs, model  No. LA1401-A
+      - name: Lens2
+        description:  Lens focus at 30 mm.
+        manufacturer: Thorlabs, model  No. LA1805
+      - name: CollimatingBeamProbe
+        description:  Light from the LEDs is filtered, coupled into a liquid light guide with lenses and the collimating beam probe.
+        manufacturer: Newport, model No. 76600
+      - name: MicroscopeObjective
+        description:  Magnification 10x, Numerical Aperture 0.3.
+        manufacturer: Olympus, model No. UPLFLN10X2
+      - name: TubeLens
+        description:  A tube lens in each path focuses emission light onto the CMOS sensors of the cameras to form an image of the fiber bundle.
+        manufacturer: Thorlabs, model No. TTL165-A
+      - name: MicroManipulator
+        description:  The microscope was attached to a micromanipulator to allow fine manual focusing and mounted on a rotatable arm extending over the head-fixation setup to allow for coarse positioning of the objective over the mouse.
+        manufacturer: Newport, model No 9067-XYZ-R
+    BandOpticalFilters:
+      - name: OpticalFilter405
+        description: The band-pass filter used to isolate the 405 and 415 nm excitation light.
+        manufacturer: Chroma
+        model: ET405/10
+        center_wavelength_in_nm: 405.0
+        bandwidth_in_nm: 10.0
+        filter_type: Bandpass
+      - name: OpticalFilter473
+        description: The band-pass filter used to isolate the 470 nm excitation light.
+        manufacturer: Chroma
+        model: ET473/24
+        center_wavelength_in_nm: 473.0
+        bandwidth_in_nm: 24.0
+        filter_type: Bandpass
+      - name: OpticalFilter555
+        description: The band-pass filter used to isolate the 570 nm excitation light.
+        manufacturer: Chroma
+        model: ET555/25
+        center_wavelength_in_nm: 555.0
+        bandwidth_in_nm: 25.0
+        filter_type: Bandpass
+      - name: OpticalFilter525
+        description: The band-pass filter used to isolate the green emitted light after passing through a dichroic (Chroma, No. 532rdc) that reflected green and passed red fluorescence.
+        manufacturer: Chroma
+        model: 525/50m
+        center_wavelength_in_nm: 525.0
+        bandwidth_in_nm: 50.0
+        filter_type: Bandpass
+    EdgeOpticalFilter:
+      - name: OpticalFilter570
+        description: The band-pass filter used to isolate the red emitted light after passing through a dichroic (Chroma, No. 532rdc) that reflected green and passed red fluorescence.
+        manufacturer: Chroma
+        model: 570lp
+        cut_wavelength_in_nm: 570.0
+        filter_type: Longpass
+    DichroicMirrors:
+      - name: DichroicMirror1
+        description: The dichroic mirror used to reflect green and pass red fluorescence 
+        manufacturer: Chroma Tech Corp
+        model: ZT532rdc
+        cut_on_wavelength_in_nm: 532.0
+        transmission_band_in_nm: [545.0, 750.0]
+        reflection_band_in_nm: [405.0, 532.0]
+      - name: DichroicMirror2
+        description: The dichroic mirror used to direct the excitation light
+        manufacturer: Chroma Tech Corp
+        model: 405rdc
+        cut_on_wavelength_in_nm: 405
+        transmission_band_in_nm: [430.0, 820.0]
+        reflection_band_in_nm: [387.0, 420.0]
+      - name: DichroicMirror3a
+        description: The dichroic mirror used to reflect the excitation light. A multiband beamsplitter described by DichroicMirror3a and DichroicMirror3b.
+        manufacturer: Chroma Tech Corp
+        model: 59009bs
+        cut_on_wavelength_in_nm: 523
+        transmission_band_in_nm: [510.0, 540.0]
+      - name: DichroicMirror3b
+        description: The dichroic mirror used to reflect the excitation light. A multiband beamsplitter described by DichroicMirror3a and DichroicMirror3b.
+        manufacturer: Chroma Tech Corp
+        model: 59009bs
+        cut_on_wavelength_in_nm: 640
+        transmission_band_in_nm: [590.0, 680.0]
+    Indicator:
+      - name: GCaMP7f
+        description: Green calcium sensor
+        label: pGP-AAV-syn-FLEX-jGCaMP7fWPRE
+        injection_location: 
+        injection_coordinates_in_mm: []
+      - name: dLight1.3b
+        description: green dopamine sensor
+        label: pAAV-CAG-dLight1.3b(AAV5)
+        injection_location: 
+        injection_coordinates_in_mm: []
+      - name: Ach3.0
+        description: green acetyl cholinesensor
+        label: AAV9-hSyn-Ach3.0
+        injection_location: 
+        injection_coordinates_in_mm: []
+      - name: jRGECO1a
+        description: Red calcium sensor
+        label: pAAV-syn-FLEX-NESjRGECO1a-WPRE-SV40(AAV1)
+        injection_location: 
+        injection_coordinates_in_mm: []
+      - name: rDA3m
+        description: Red dopamine sensor
+        label: pAAV-hsyn-rDA3m(AAV2/9)
+        injection_location: 
+        injection_coordinates_in_mm: []
+      - name: tdTomato
+        description: Red static marker
+        label: pAAV-CAG-tdTomato(codon diversified-AAV1)
+        injection_location: 
+        injection_coordinates_in_mm: []
+

--- a/src/howe_lab_to_nwb/vu2024/metadata/vu2024_fiber_photometry_metadata.yaml
+++ b/src/howe_lab_to_nwb/vu2024/metadata/vu2024_fiber_photometry_metadata.yaml
@@ -155,31 +155,19 @@ Ophys:
       - name: GCaMP7f
         description: Green calcium sensor
         label: pGP-AAV-syn-FLEX-jGCaMP7fWPRE
-        injection_location: 
-        injection_coordinates_in_mm: []
       - name: dLight1.3b
         description: green dopamine sensor
         label: pAAV-CAG-dLight1.3b(AAV5)
-        injection_location: 
-        injection_coordinates_in_mm: []
       - name: Ach3.0
         description: green acetyl cholinesensor
         label: AAV9-hSyn-Ach3.0
-        injection_location: 
-        injection_coordinates_in_mm: []
       - name: jRGECO1a
         description: Red calcium sensor
         label: pAAV-syn-FLEX-NESjRGECO1a-WPRE-SV40(AAV1)
-        injection_location: 
-        injection_coordinates_in_mm: []
       - name: rDA3m
         description: Red dopamine sensor
         label: pAAV-hsyn-rDA3m(AAV2/9)
-        injection_location: 
-        injection_coordinates_in_mm: []
       - name: tdTomato
         description: Red static marker
         label: pAAV-CAG-tdTomato(codon diversified-AAV1)
-        injection_location: 
-        injection_coordinates_in_mm: []
 

--- a/src/howe_lab_to_nwb/vu2024/vu2024_notes.md
+++ b/src/howe_lab_to_nwb/vu2024/vu2024_notes.md
@@ -1,1 +1,14 @@
 # Notes concerning the vu2024 conversion
+## From protocol.io 
+### Head-Fixed mice
+Micro-fiber array approach capable of chronically measuring and optogenetically manipulating local dynamics across over 100 targeted locations simultaneously in head-fixed and freely moving mice, enabling investigation of cell-type and neurotransmitter-specific signals over arbitrary 3-D volumes . This protocol includes the steps for imaging in freely-moving mice. 
+
+* *[Multi-color fiber array imaging](dx.doi.org/10.17504/protocols.io.14egn31qml5d/v1)*
+ Injections to target midbrain DA neurons for the dual-wavelength recordings (Figure S2C) were performed 3.07mm caudal to the bregma at four sites: ML = 0.5mm, DV =-4.00 mm and -4.25 mm, ML = 1mm, DV = -4.125mm and ML = 1.5 mm, DV = -3.8 mm below the dura, 200-400nL at each site at a rate ∼ 100 nL/min. 
+* *[Targeted optogenetic stimulations](dx.doi.org/10.17504/protocols.io.5jyl8pxz6g2w/v1)*
+Injections were targeted to the midbrain for the stimulation experiment (Figure 6) at 4 sites relative to bregma: AP = -3.05, ML = 0.6, DV = -4.6 and DV = -4.25; AP = -3.5, ML = 1.25, DV = -3.9 and DV = -4.5.
+Effector: hChR2
+    - name: hChR2
+      description: Blue light opsin
+      label: pAAV-EF1a-doublefloxed hChR2(H134R)EYFP-WPRE-HG HpA(AAV1)
+### Freely-moving mice


### PR DESCRIPTION
Added fiber photometry metadata, mainly devices. The setup is quite complicated.
Note that:

-  their photodetector is a CMOS sensor that is not described by a detected wavelength. I defined that as a simple Device, along with all the other components of the setup.
- There is a dichroic mirror that has a dual-band transmission characteristic. I define two separate DichroicMirror devices and call them `DichroicMirror3a` and `DichroicMirror3b` and explicitly the single transmission band for each.
- We need to ask if the OpticalFilter with CW 405 nm is also used to filter the 415 nm excitation.
- The `injection_location` and `injection_coordinates_in_mm` are available, but they have not been reported for the specific indicator or opsin. I guess we will need to specify it subject by subject. 