### PR TITLE
Add included ROIs from fiber locations

### DIFF
--- a/src/howe_lab_to_nwb/vu2024/utils/add_fiber_photometry.py
+++ b/src/howe_lab_to_nwb/vu2024/utils/add_fiber_photometry.py
@@ -53,7 +53,7 @@ def add_fiber_photometry_table(nwbfile: NWBFile, metadata: dict):
         description="The fiber tip coordinates (AP, ML, DV) in Allen Brain Atlas coordinates",
     )
     fiber_photometry_table.add_column(
-        name="is_good_fiber",
+        name="included",
         description="Whether this fiber has been successfully implanted.",
     )
 
@@ -180,9 +180,9 @@ def add_fiber_photometry_series(
     if default_series_name not in nwbfile.acquisition:
         for fiber_ind in range(num_fibers):
             brain_area = fiber_locations_metadata[fiber_ind]["location"]
-            is_good_fiber = True if brain_area else False
+            included = fiber_locations_metadata[fiber_ind]["included"]
             fiber_photometry_table.add_row(
-                is_good_fiber=is_good_fiber,
+                included=included,
                 location=brain_area,  # TODO: change this in the extension to brain_area
                 coordinates=fiber_locations_metadata[fiber_ind]["coordinates"],
                 allen_atlas_coordinates=fiber_locations_metadata[fiber_ind]["allen_atlas_coordinates"],
@@ -264,6 +264,7 @@ def get_fiber_locations(file_path: FilePathType) -> List[dict]:
             allen_atlas_coordinates=allen_atlas_coordinates,
             # TODO: rename to brain_area
             location=brain_area,
+            included=row["included"],
         )
         fibers_metadata.append(fiber_metadata)
 

--- a/src/howe_lab_to_nwb/vu2024/vu2024_convert_single_wavelength_session.py
+++ b/src/howe_lab_to_nwb/vu2024/vu2024_convert_single_wavelength_session.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Union, Optional, List
 
 from dateutil import tz
+from neuroconv.tools.nwb_helpers import configure_and_write_nwbfile
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 from pynwb import NWBFile
 
@@ -209,13 +210,7 @@ def single_wavelength_session_to_nwb(
     if nwbfile_path is None:
         return nwbfile
 
-    converter.run_conversion(
-        nwbfile_path=nwbfile_path,
-        nwbfile=nwbfile,
-        metadata=metadata,
-        conversion_options=conversion_options,
-        overwrite=True,
-    )
+    configure_and_write_nwbfile(nwbfile=nwbfile, output_filepath=nwbfile_path)
 
 
 if __name__ == "__main__":

--- a/src/howe_lab_to_nwb/vu2024/vu2024_convert_single_wavelength_session.py
+++ b/src/howe_lab_to_nwb/vu2024/vu2024_convert_single_wavelength_session.py
@@ -119,7 +119,7 @@ def single_wavelength_session_to_nwb(
     )
 
     # Add ROI segmentation
-    accepted_list = [fiber_ind for fiber_ind, fiber in enumerate(fiber_locations_metadata) if fiber["location"] != ""]
+    accepted_list = [fiber_ind for fiber_ind, fiber in enumerate(fiber_locations_metadata) if fiber["included"]]
     roi_source_data = dict(
         file_path=str(raw_fiber_photometry_file_path),
         sampling_frequency=sampling_frequency,


### PR DESCRIPTION
Modify the ROI acceptance/rejection list to use “included” column from fiber location .xlsx tables
In the FiberPhotometryTable rename "is_good_fiber" to "included"

[Example file](https://us-east-2.console.aws.amazon.com/s3/object/catalystneuro-processing?region=us-east-2&bucketType=general&prefix=howe-lab-to-nwb/GridDL-18_211110.nwb)